### PR TITLE
Feature/global search

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/AppAdapter.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/AppAdapter.kt
@@ -67,6 +67,17 @@ class AppAdapter(
     val items: MutableList<Item> = mutableListOf()
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
+    // --- LISTENERS AÑADIDOS AQUÍ ---
+    var onMovieClickListener: ((Movie) -> Unit)? = null
+    var onTvShowClickListener: ((TvShow) -> Unit)? = null
+    var onMovieLongClickListener: ((Movie) -> Unit)? = null
+    var onTvShowLongClickListener: ((TvShow) -> Unit)? = null
+    var onGenreClickListener: ((Genre) -> Unit)? = null
+    var onPeopleClickListener: ((People) -> Unit)? = null
+    var onEpisodeClickListener: ((Episode) -> Unit)? = null
+    var onSeasonClickListener: ((Season) -> Unit)? = null
+    var onProviderClickListener: ((Provider) -> Unit)? = null
+    // ---------------------------------
     interface Item {
         var itemType: Type
     }
@@ -459,16 +470,34 @@ class AppAdapter(
 
         val adjustedPosition = header?.let { position - 1 } ?: position
         when (holder) {
-            is CategoryViewHolder -> holder.bind(items[adjustedPosition] as Category)
-            is EpisodeViewHolder -> holder.bind(items[adjustedPosition] as Episode)
+            is CategoryViewHolder -> holder.bind(
+                items[adjustedPosition] as Category,
+                onMovieClickListener,
+                onTvShowClickListener,
+            )
+            is EpisodeViewHolder -> holder.bind(
+                items[adjustedPosition] as Episode
+            ) // Tu original no pasaba listener, lo respeto
             is FooterViewHolder -> footer?.bind?.invoke(holder.binding)
-            is GenreViewHolder -> holder.bind(items[adjustedPosition] as Genre)
+            is GenreViewHolder -> holder.bind(
+                items[adjustedPosition] as Genre
+            ) // Tu original no pasaba listener, lo respeto
             is HeaderViewHolder -> header?.bind?.invoke(holder.binding)
-            is MovieViewHolder -> holder.bind(items[adjustedPosition] as Movie)
-            is PeopleViewHolder -> holder.bind(items[adjustedPosition] as People)
-            is ProviderViewHolder -> holder.bind(items[adjustedPosition] as Provider)
-            is SeasonViewHolder -> holder.bind(items[adjustedPosition] as Season)
-            is TvShowViewHolder -> holder.bind(items[adjustedPosition] as TvShow)
+            is MovieViewHolder -> holder.bind(
+                items[adjustedPosition] as Movie
+            ) // Los listeners se manejan dentro del ViewHolder
+            is PeopleViewHolder -> holder.bind(
+                items[adjustedPosition] as People
+            ) // Tu original no pasaba listener, lo respeto
+            is ProviderViewHolder -> holder.bind(
+                items[adjustedPosition] as Provider
+            ) // Tu original no pasaba listener, lo respeto
+            is SeasonViewHolder -> holder.bind(
+                items[adjustedPosition] as Season
+            ) // Tu original no pasaba listener, lo respeto
+            is TvShowViewHolder -> holder.bind(
+                items[adjustedPosition] as TvShow
+            ) // Los listeners se manejan dentro del ViewHolder
         }
 
         val state = states[holder.layoutPosition]

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/CategoryViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/CategoryViewHolder.kt
@@ -77,7 +77,7 @@ class CategoryViewHolder(
 
         binding.rvCategory.apply {
             adapter = AppAdapter().apply {
-                // AQUÍ ESTÁ LA MAGIA: Pasamos los listeners al adaptador interno
+
                 this.onMovieClickListener = onMovieClick
                 this.onTvShowClickListener = onTvShowClick
                 submitList(category.list)
@@ -94,27 +94,18 @@ class CategoryViewHolder(
         onTvShowClick: ((TvShow) -> Unit)?
     ) {
         binding.tvCategoryTitle.text = category.name
-
         binding.hgvCategory.apply {
             setRowHeight(ViewGroup.LayoutParams.WRAP_CONTENT)
 
-            // --- INICIO DE LA MODIFICACIÓN ---
-            // 1. Creamos el adaptador para la lista horizontal.
-            // 2. Le pasamos los listeners que este ViewHolder recibió del adaptador principal.
             adapter = AppAdapter().apply {
                 this.onMovieClickListener = onMovieClick
                 this.onTvShowClickListener = onTvShowClick
                 submitList(category.list)
             }
-            // --- FIN DE LA MODIFICACIÓN ---
-
             setItemSpacing(category.itemSpacing)
 
-            // --- MANTENEMOS LA SOLUCIÓN DE FOCO ---
-            // Esto es crucial para que el D-Pad pueda navegar por los items.
             isFocusable = true
             descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
-            // --- FIN DE LA SOLUCIÓN DE FOCO ---
         }
     }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/CategoryViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/CategoryViewHolder.kt
@@ -97,13 +97,24 @@ class CategoryViewHolder(
 
         binding.hgvCategory.apply {
             setRowHeight(ViewGroup.LayoutParams.WRAP_CONTENT)
+
+            // --- INICIO DE LA MODIFICACIÓN ---
+            // 1. Creamos el adaptador para la lista horizontal.
+            // 2. Le pasamos los listeners que este ViewHolder recibió del adaptador principal.
             adapter = AppAdapter().apply {
-                // AQUÍ ESTÁ LA MAGIA: Pasamos los listeners al adaptador interno
                 this.onMovieClickListener = onMovieClick
                 this.onTvShowClickListener = onTvShowClick
                 submitList(category.list)
             }
+            // --- FIN DE LA MODIFICACIÓN ---
+
             setItemSpacing(category.itemSpacing)
+
+            // --- MANTENEMOS LA SOLUCIÓN DE FOCO ---
+            // Esto es crucial para que el D-Pad pueda navegar por los items.
+            isFocusable = true
+            descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
+            // --- FIN DE LA SOLUCIÓN DE FOCO ---
         }
     }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
@@ -189,28 +189,22 @@ class MovieViewHolder(
 
     private fun displayTvItem(binding: ItemMovieTvBinding) {
         binding.root.apply {
-            setOnClickListener {
-                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
-                    when (context.toActivity()?.getCurrentFragment()) {
-                        is HomeTvFragment -> {
-                            findNavController().navigate(HomeTvFragmentDirections.actionHomeToMovie(id = movie.id))
-                            if (movie.itemType == AppAdapter.Type.MOVIE_CONTINUE_WATCHING_TV_ITEM) {
-                                findNavController().navigate(MovieTvFragmentDirections.actionMovieToPlayer(
-                                    id = movie.id,
-                                    title = movie.title,
-                                    subtitle = movie.released?.format("yyyy") ?: "",
-                                    videoType = Video.Type.Movie(id = movie.id, title = movie.title, releaseDate = movie.released?.format("yyyy-MM-dd") ?: "", poster = movie.poster ?: ""),
-                                ))
-                            }
-                        }
-                        is MovieTvFragment -> findNavController().navigate(MovieTvFragmentDirections.actionMovieToMovie(id = movie.id))
-                        is TvShowTvFragment -> findNavController().navigate(TvShowTvFragmentDirections.actionTvShowToMovie(id = movie.id))
-                    }
+            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA GLOBAL) ---
+            isFocusable = true
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
+                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
+                ) {
+                    // Llama al listener del adaptador al que pertenece este ViewHolder
+                    (bindingAdapter as? AppAdapter)?.onMovieClickListener?.invoke(movie)
+                    return@setOnKeyListener true // Evento manejado
                 }
+                return@setOnKeyListener false // Dejar que el sistema maneje otras teclas
             }
+            // --- FIN DE LA MODIFICACIÓN ---
+
             setOnLongClickListener {
-                ShowOptionsTvDialog(context, movie)
-                    .show()
+                ShowOptionsTvDialog(context, movie).show()
                 true
             }
             setOnFocusChangeListener { _, hasFocus ->
@@ -228,17 +222,15 @@ class MovieViewHolder(
                 }
             }
         }
-
+        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
         Glide.with(context)
             .load(movie.poster)
             .fallback(R.drawable.glide_fallback_cover)
             .centerCrop()
             .transition(DrawableTransitionOptions.withCrossFade())
             .into(binding.ivMoviePoster)
-
         binding.pbMovieProgress.apply {
             val watchHistory = movie.watchHistory
-
             progress = when {
                 watchHistory != null -> (watchHistory.lastPlaybackPositionMillis * 100 / watchHistory.durationMillis.toDouble()).toInt()
                 else -> 0
@@ -248,7 +240,6 @@ class MovieViewHolder(
                 else -> View.GONE
             }
         }
-
         binding.tvMovieQuality.apply {
             text = movie.quality ?: ""
             visibility = when {
@@ -256,10 +247,8 @@ class MovieViewHolder(
                 else -> View.VISIBLE
             }
         }
-
         binding.tvMovieReleasedYear.text = movie.released?.format("yyyy")
             ?: context.getString(R.string.movie_item_type)
-
         binding.tvMovieTitle.text = movie.title
     }
 
@@ -316,19 +305,22 @@ class MovieViewHolder(
 
     private fun displayGridTvItem(binding: ItemMovieGridTvBinding) {
         binding.root.apply {
-            setOnClickListener {
-                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
-                    when (context.toActivity()?.getCurrentFragment()) {
-                        is GenreTvFragment -> findNavController().navigate(GenreTvFragmentDirections.actionGenreToMovie(id = movie.id))
-                        is MoviesTvFragment -> findNavController().navigate(MoviesTvFragmentDirections.actionMoviesToMovie(id = movie.id))
-                        is PeopleTvFragment -> findNavController().navigate(PeopleTvFragmentDirections.actionPeopleToMovie(id = movie.id))
-                        is SearchTvFragment -> findNavController().navigate(SearchTvFragmentDirections.actionSearchToMovie(id = movie.id))
-                    }
+            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA NORMAL) ---
+            isFocusable = true
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
+                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
+                ) {
+                    // Llama al listener del adaptador al que pertenece este ViewHolder
+                    (bindingAdapter as? AppAdapter)?.onMovieClickListener?.invoke(movie)
+                    return@setOnKeyListener true // Evento manejado
                 }
+                return@setOnKeyListener false // Dejar que el sistema maneje otras teclas
             }
+            // --- FIN DE LA MODIFICACIÓN ---
+
             setOnLongClickListener {
-                ShowOptionsTvDialog(context, movie)
-                    .show()
+                ShowOptionsTvDialog(context, movie).show()
                 true
             }
             setOnFocusChangeListener { _, hasFocus ->
@@ -340,17 +332,15 @@ class MovieViewHolder(
                 animation.fillAfter = true
             }
         }
-
+        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
         Glide.with(context)
             .load(movie.poster)
             .fallback(R.drawable.glide_fallback_cover)
             .centerCrop()
             .transition(DrawableTransitionOptions.withCrossFade())
             .into(binding.ivMoviePoster)
-
         binding.pbMovieProgress.apply {
             val watchHistory = movie.watchHistory
-
             progress = when {
                 watchHistory != null -> (watchHistory.lastPlaybackPositionMillis * 100 / watchHistory.durationMillis.toDouble()).toInt()
                 else -> 0
@@ -360,7 +350,6 @@ class MovieViewHolder(
                 else -> View.GONE
             }
         }
-
         binding.tvMovieQuality.apply {
             text = movie.quality ?: ""
             visibility = when {
@@ -368,10 +357,8 @@ class MovieViewHolder(
                 else -> View.VISIBLE
             }
         }
-
         binding.tvMovieReleasedYear.text = movie.released?.format("yyyy")
             ?: context.getString(R.string.movie_item_type)
-
         binding.tvMovieTitle.text = movie.title
     }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
@@ -69,6 +69,8 @@ import com.streamflixreborn.streamflix.utils.format
 import com.streamflixreborn.streamflix.utils.getCurrentFragment
 import com.streamflixreborn.streamflix.utils.toActivity
 import java.util.Locale
+import com.streamflixreborn.streamflix.utils.UserPreferences
+import com.streamflixreborn.streamflix.providers.Provider
 
 class MovieViewHolder(
     private val _binding: ViewBinding
@@ -115,49 +117,39 @@ class MovieViewHolder(
             is ContentMovieRecommendationsTvBinding -> displayRecommendationsTv(_binding)
         }
     }
-
+    // --- NUESTRA FUNCIÓN AYUDANTE ---
+    private fun checkProviderAndRun(action: () -> Unit) {
+        if (!movie.providerName.isNullOrBlank() && movie.providerName != UserPreferences.currentProvider?.name) {
+            Provider.providers.keys.find { it.name == movie.providerName }?.let {
+                UserPreferences.currentProvider = it
+            }
+        }
+        action() // Ejecuta la navegación original
+    }
 
     private fun displayMobileItem(binding: ItemMovieMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is HomeMobileFragment -> {
-                        findNavController().navigate(
-                            HomeMobileFragmentDirections.actionHomeToMovie(
-                                id = movie.id
-                            )
-                        )
-                        if (movie.itemType == AppAdapter.Type.MOVIE_CONTINUE_WATCHING_MOBILE_ITEM) {
-                            findNavController().navigate(
-                                MovieMobileFragmentDirections.actionMovieToPlayer(
+                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is HomeMobileFragment -> {
+                            findNavController().navigate(HomeMobileFragmentDirections.actionHomeToMovie(id = movie.id))
+                            if (movie.itemType == AppAdapter.Type.MOVIE_CONTINUE_WATCHING_MOBILE_ITEM) {
+                                findNavController().navigate(MovieMobileFragmentDirections.actionMovieToPlayer(
                                     id = movie.id,
                                     title = movie.title,
                                     subtitle = movie.released?.format("yyyy") ?: "",
-                                    videoType = Video.Type.Movie(
-                                        id = movie.id,
-                                        title = movie.title,
-                                        releaseDate = movie.released?.format("yyyy-MM-dd") ?: "",
-                                        poster = movie.poster ?: "",
-                                    ),
-                                )
-                            )
+                                    videoType = Video.Type.Movie(id = movie.id, title = movie.title, releaseDate = movie.released?.format("yyyy-MM-dd") ?: "", poster = movie.poster ?: ""),
+                                ))
+                            }
                         }
+                        is MovieMobileFragment -> findNavController().navigate(MovieMobileFragmentDirections.actionMovieToMovie(id = movie.id))
+                        is TvShowMobileFragment -> findNavController().navigate(TvShowMobileFragmentDirections.actionTvShowToMovie(id = movie.id))
                     }
-                    is MovieMobileFragment -> findNavController().navigate(
-                        MovieMobileFragmentDirections.actionMovieToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is TvShowMobileFragment -> findNavController().navigate(
-                        TvShowMobileFragmentDirections.actionTvShowToMovie(
-                            id = movie.id
-                        )
-                    )
                 }
             }
             setOnLongClickListener {
-                ShowOptionsMobileDialog(context, movie)
-                    .show()
+                ShowOptionsMobileDialog(context, movie).show()
                 true
             }
         }
@@ -198,39 +190,22 @@ class MovieViewHolder(
     private fun displayTvItem(binding: ItemMovieTvBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is HomeTvFragment -> {
-                        findNavController().navigate(
-                            HomeTvFragmentDirections.actionHomeToMovie(
-                                id = movie.id
-                            )
-                        )
-                        if (movie.itemType == AppAdapter.Type.MOVIE_CONTINUE_WATCHING_TV_ITEM) {
-                            findNavController().navigate(
-                                MovieTvFragmentDirections.actionMovieToPlayer(
+                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is HomeTvFragment -> {
+                            findNavController().navigate(HomeTvFragmentDirections.actionHomeToMovie(id = movie.id))
+                            if (movie.itemType == AppAdapter.Type.MOVIE_CONTINUE_WATCHING_TV_ITEM) {
+                                findNavController().navigate(MovieTvFragmentDirections.actionMovieToPlayer(
                                     id = movie.id,
                                     title = movie.title,
                                     subtitle = movie.released?.format("yyyy") ?: "",
-                                    videoType = Video.Type.Movie(
-                                        id = movie.id,
-                                        title = movie.title,
-                                        releaseDate = movie.released?.format("yyyy-MM-dd") ?: "",
-                                        poster = movie.poster ?: "",
-                                    ),
-                                )
-                            )
+                                    videoType = Video.Type.Movie(id = movie.id, title = movie.title, releaseDate = movie.released?.format("yyyy-MM-dd") ?: "", poster = movie.poster ?: ""),
+                                ))
+                            }
                         }
+                        is MovieTvFragment -> findNavController().navigate(MovieTvFragmentDirections.actionMovieToMovie(id = movie.id))
+                        is TvShowTvFragment -> findNavController().navigate(TvShowTvFragmentDirections.actionTvShowToMovie(id = movie.id))
                     }
-                    is MovieTvFragment -> findNavController().navigate(
-                        MovieTvFragmentDirections.actionMovieToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is TvShowTvFragment -> findNavController().navigate(
-                        TvShowTvFragmentDirections.actionTvShowToMovie(
-                            id = movie.id
-                        )
-                    )
                 }
             }
             setOnLongClickListener {
@@ -291,32 +266,17 @@ class MovieViewHolder(
     private fun displayGridMobileItem(binding: ItemMovieGridMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is GenreMobileFragment -> findNavController().navigate(
-                        GenreMobileFragmentDirections.actionGenreToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is MoviesMobileFragment -> findNavController().navigate(
-                        MoviesMobileFragmentDirections.actionMoviesToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is PeopleMobileFragment -> findNavController().navigate(
-                        PeopleMobileFragmentDirections.actionPeopleToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is SearchMobileFragment -> findNavController().navigate(
-                        SearchMobileFragmentDirections.actionSearchToMovie(
-                            id = movie.id
-                        )
-                    )
+                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is GenreMobileFragment -> findNavController().navigate(GenreMobileFragmentDirections.actionGenreToMovie(id = movie.id))
+                        is MoviesMobileFragment -> findNavController().navigate(MoviesMobileFragmentDirections.actionMoviesToMovie(id = movie.id))
+                        is PeopleMobileFragment -> findNavController().navigate(PeopleMobileFragmentDirections.actionPeopleToMovie(id = movie.id))
+                        is SearchMobileFragment -> findNavController().navigate(SearchMobileFragmentDirections.actionSearchToMovie(id = movie.id))
+                    }
                 }
             }
             setOnLongClickListener {
-                ShowOptionsMobileDialog(context, movie)
-                    .show()
+                ShowOptionsMobileDialog(context, movie).show()
                 true
             }
         }
@@ -357,27 +317,13 @@ class MovieViewHolder(
     private fun displayGridTvItem(binding: ItemMovieGridTvBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is GenreTvFragment -> findNavController().navigate(
-                        GenreTvFragmentDirections.actionGenreToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is MoviesTvFragment -> findNavController().navigate(
-                        MoviesTvFragmentDirections.actionMoviesToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is PeopleTvFragment -> findNavController().navigate(
-                        PeopleTvFragmentDirections.actionPeopleToMovie(
-                            id = movie.id
-                        )
-                    )
-                    is SearchTvFragment -> findNavController().navigate(
-                        SearchTvFragmentDirections.actionSearchToMovie(
-                            id = movie.id
-                        )
-                    )
+                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is GenreTvFragment -> findNavController().navigate(GenreTvFragmentDirections.actionGenreToMovie(id = movie.id))
+                        is MoviesTvFragment -> findNavController().navigate(MoviesTvFragmentDirections.actionMoviesToMovie(id = movie.id))
+                        is PeopleTvFragment -> findNavController().navigate(PeopleTvFragmentDirections.actionPeopleToMovie(id = movie.id))
+                        is SearchTvFragment -> findNavController().navigate(SearchTvFragmentDirections.actionSearchToMovie(id = movie.id))
+                    }
                 }
             }
             setOnLongClickListener {
@@ -565,19 +511,16 @@ class MovieViewHolder(
 
         binding.btnMovieWatchNow.apply {
             setOnClickListener {
-                findNavController().navigate(
-                    MovieMobileFragmentDirections.actionMovieToPlayer(
+                // Este botón ya navega al reproductor, no a otra página de detalles.
+                // Generalmente no necesita el cambio de proveedor, pero lo añadimos por seguridad.
+                checkProviderAndRun {
+                    findNavController().navigate(MovieMobileFragmentDirections.actionMovieToPlayer(
                         id = movie.id,
                         title = movie.title,
                         subtitle = movie.released?.format("yyyy") ?: "",
-                        videoType = Video.Type.Movie(
-                            id = movie.id,
-                            title = movie.title,
-                            releaseDate = movie.released?.format("yyyy-MM-dd") ?: "",
-                            poster = movie.poster ?: movie.banner ?: "",
-                        ),
-                    )
-                )
+                        videoType = Video.Type.Movie(id = movie.id, title = movie.title, releaseDate = movie.released?.format("yyyy-MM-dd") ?: "", poster = movie.poster ?: movie.banner ?: ""),
+                    ))
+                }
             }
         }
 
@@ -764,19 +707,14 @@ class MovieViewHolder(
 
         binding.btnMovieWatchNow.apply {
             setOnClickListener {
-                findNavController().navigate(
-                    MovieTvFragmentDirections.actionMovieToPlayer(
+                checkProviderAndRun {
+                    findNavController().navigate(MovieTvFragmentDirections.actionMovieToPlayer(
                         id = movie.id,
                         title = movie.title,
                         subtitle = movie.released?.format("yyyy") ?: "",
-                        videoType = Video.Type.Movie(
-                            id = movie.id,
-                            title = movie.title,
-                            releaseDate = movie.released?.format("yyyy-MM-dd") ?: "",
-                            poster = movie.poster ?: movie.banner ?: "",
-                        ),
-                    )
-                )
+                        videoType = Video.Type.Movie(id = movie.id, title = movie.title, releaseDate = movie.released?.format("yyyy-MM-dd") ?: "", poster = movie.poster ?: movie.banner ?: ""),
+                    ))
+                }
             }
         }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
@@ -71,6 +71,7 @@ import com.streamflixreborn.streamflix.utils.toActivity
 import java.util.Locale
 import com.streamflixreborn.streamflix.utils.UserPreferences
 import com.streamflixreborn.streamflix.providers.Provider
+import android.view.KeyEvent
 
 class MovieViewHolder(
     private val _binding: ViewBinding
@@ -117,20 +118,20 @@ class MovieViewHolder(
             is ContentMovieRecommendationsTvBinding -> displayRecommendationsTv(_binding)
         }
     }
-    // --- NUESTRA FUNCIÓN AYUDANTE ---
+
     private fun checkProviderAndRun(action: () -> Unit) {
         if (!movie.providerName.isNullOrBlank() && movie.providerName != UserPreferences.currentProvider?.name) {
             Provider.providers.keys.find { it.name == movie.providerName }?.let {
                 UserPreferences.currentProvider = it
             }
         }
-        action() // Ejecuta la navegación original
+        action()
     }
 
     private fun displayMobileItem(binding: ItemMovieMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
+                checkProviderAndRun {
                     when (context.toActivity()?.getCurrentFragment()) {
                         is HomeMobileFragment -> {
                             findNavController().navigate(HomeMobileFragmentDirections.actionHomeToMovie(id = movie.id))
@@ -189,19 +190,15 @@ class MovieViewHolder(
 
     private fun displayTvItem(binding: ItemMovieTvBinding) {
         binding.root.apply {
-            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA GLOBAL) ---
             isFocusable = true
             setOnKeyListener { _, keyCode, event ->
-                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
-                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
-                ) {
-                    // Llama al listener del adaptador al que pertenece este ViewHolder
+                if (event.action == KeyEvent.ACTION_DOWN && (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)) {
                     (bindingAdapter as? AppAdapter)?.onMovieClickListener?.invoke(movie)
-                    return@setOnKeyListener true // Evento manejado
+                    return@setOnKeyListener true
                 }
-                return@setOnKeyListener false // Dejar que el sistema maneje otras teclas
+                return@setOnKeyListener false
             }
-            // --- FIN DE LA MODIFICACIÓN ---
+
 
             setOnLongClickListener {
                 ShowOptionsTvDialog(context, movie).show()
@@ -222,7 +219,7 @@ class MovieViewHolder(
                 }
             }
         }
-        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
+
         Glide.with(context)
             .load(movie.poster)
             .fallback(R.drawable.glide_fallback_cover)
@@ -255,7 +252,7 @@ class MovieViewHolder(
     private fun displayGridMobileItem(binding: ItemMovieGridMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                checkProviderAndRun { // <-- USAMOS NUESTRA LÓGICA
+                checkProviderAndRun {
                     when (context.toActivity()?.getCurrentFragment()) {
                         is GenreMobileFragment -> findNavController().navigate(GenreMobileFragmentDirections.actionGenreToMovie(id = movie.id))
                         is MoviesMobileFragment -> findNavController().navigate(MoviesMobileFragmentDirections.actionMoviesToMovie(id = movie.id))
@@ -305,19 +302,14 @@ class MovieViewHolder(
 
     private fun displayGridTvItem(binding: ItemMovieGridTvBinding) {
         binding.root.apply {
-            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA NORMAL) ---
             isFocusable = true
             setOnKeyListener { _, keyCode, event ->
-                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
-                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
-                ) {
-                    // Llama al listener del adaptador al que pertenece este ViewHolder
+                if (event.action == KeyEvent.ACTION_DOWN && (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)) {
                     (bindingAdapter as? AppAdapter)?.onMovieClickListener?.invoke(movie)
-                    return@setOnKeyListener true // Evento manejado
+                    return@setOnKeyListener true
                 }
-                return@setOnKeyListener false // Dejar que el sistema maneje otras teclas
+                return@setOnKeyListener false
             }
-            // --- FIN DE LA MODIFICACIÓN ---
 
             setOnLongClickListener {
                 ShowOptionsTvDialog(context, movie).show()
@@ -332,7 +324,6 @@ class MovieViewHolder(
                 animation.fillAfter = true
             }
         }
-        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
         Glide.with(context)
             .load(movie.poster)
             .fallback(R.drawable.glide_fallback_cover)

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
@@ -73,7 +73,7 @@ import com.streamflixreborn.streamflix.utils.toActivity
 import java.util.Locale
 import com.streamflixreborn.streamflix.utils.UserPreferences
 import com.streamflixreborn.streamflix.providers.Provider
-
+import android.view.KeyEvent
 class TvShowViewHolder(
     private val _binding: ViewBinding
 ) : RecyclerView.ViewHolder(
@@ -135,7 +135,7 @@ class TvShowViewHolder(
     private fun displayMobileItem(binding: ItemTvShowMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                checkProviderAndRun { // <-- LÓGICA APLICADA
+                checkProviderAndRun {
                     when (context.toActivity()?.getCurrentFragment()) {
                         is HomeMobileFragment -> findNavController().navigate(
                             HomeMobileFragmentDirections.actionHomeToTvShow(id = tvShow.id)
@@ -192,19 +192,14 @@ class TvShowViewHolder(
 
     private fun displayTvItem(binding: ItemTvShowTvBinding) {
         binding.root.apply {
-            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA GLOBAL) ---
             isFocusable = true
             setOnKeyListener { _, keyCode, event ->
-                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
-                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
-                ) {
+                if (event.action == KeyEvent.ACTION_DOWN && (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)) {
                     (bindingAdapter as? AppAdapter)?.onTvShowClickListener?.invoke(tvShow)
                     return@setOnKeyListener true
                 }
                 return@setOnKeyListener false
             }
-            // --- FIN DE LA MODIFICACIÓN ---
-
             setOnLongClickListener {
                 ShowOptionsTvDialog(context, tvShow).show()
                 true
@@ -224,7 +219,7 @@ class TvShowViewHolder(
                 }
             }
         }
-        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
+
         Glide.with(context)
             .load(tvShow.poster)
             .fallback(R.drawable.glide_fallback_cover)
@@ -253,7 +248,7 @@ class TvShowViewHolder(
     private fun displayGridMobileItem(binding: ItemTvShowGridMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                checkProviderAndRun { // <-- LÓGICA APLICADA
+                checkProviderAndRun {
                     when (context.toActivity()?.getCurrentFragment()) {
                         is GenreMobileFragment -> findNavController().navigate(
                             GenreMobileFragmentDirections.actionGenreToTvShow(id = tvShow.id)
@@ -313,19 +308,14 @@ class TvShowViewHolder(
 
     private fun displayGridTvItem(binding: ItemTvShowGridBinding) {
         binding.root.apply {
-            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA NORMAL) ---
             isFocusable = true
             setOnKeyListener { _, keyCode, event ->
-                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
-                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
-                ) {
+                if (event.action == KeyEvent.ACTION_DOWN && (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER)) {
                     (bindingAdapter as? AppAdapter)?.onTvShowClickListener?.invoke(tvShow)
                     return@setOnKeyListener true
                 }
                 return@setOnKeyListener false
             }
-            // --- FIN DE LA MODIFICACIÓN ---
-
             setOnLongClickListener {
                 ShowOptionsTvDialog(context, tvShow).show()
                 true
@@ -339,7 +329,7 @@ class TvShowViewHolder(
                 animation.fillAfter = true
             }
         }
-        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
+
         Glide.with(context)
             .load(tvShow.poster)
             .fallback(R.drawable.glide_fallback_cover)

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
@@ -192,24 +192,21 @@ class TvShowViewHolder(
 
     private fun displayTvItem(binding: ItemTvShowTvBinding) {
         binding.root.apply {
-            setOnClickListener {
-                checkProviderAndRun { // <-- LÓGICA APLICADA
-                    when (context.toActivity()?.getCurrentFragment()) {
-                        is HomeTvFragment -> findNavController().navigate(
-                            HomeTvFragmentDirections.actionHomeToTvShow(id = tvShow.id)
-                        )
-                        is MovieTvFragment -> findNavController().navigate(
-                            MovieTvFragmentDirections.actionMovieToTvShow(id = tvShow.id)
-                        )
-                        is TvShowTvFragment -> findNavController().navigate(
-                            TvShowTvFragmentDirections.actionTvShowToTvShow(id = tvShow.id)
-                        )
-                    }
+            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA GLOBAL) ---
+            isFocusable = true
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
+                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
+                ) {
+                    (bindingAdapter as? AppAdapter)?.onTvShowClickListener?.invoke(tvShow)
+                    return@setOnKeyListener true
                 }
+                return@setOnKeyListener false
             }
+            // --- FIN DE LA MODIFICACIÓN ---
+
             setOnLongClickListener {
-                ShowOptionsTvDialog(context, tvShow)
-                    .show()
+                ShowOptionsTvDialog(context, tvShow).show()
                 true
             }
             setOnFocusChangeListener { _, hasFocus ->
@@ -227,14 +224,13 @@ class TvShowViewHolder(
                 }
             }
         }
-
+        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
         Glide.with(context)
             .load(tvShow.poster)
             .fallback(R.drawable.glide_fallback_cover)
             .centerCrop()
             .transition(DrawableTransitionOptions.withCrossFade())
             .into(binding.ivTvShowPoster)
-
         binding.tvTvShowQuality.apply {
             text = tvShow.quality ?: ""
             visibility = when {
@@ -242,24 +238,15 @@ class TvShowViewHolder(
                 else -> View.VISIBLE
             }
         }
-
         binding.tvTvShowLastEpisode.text = tvShow.seasons.lastOrNull()?.let { season ->
             season.episodes.lastOrNull()?.let { episode ->
                 if (season.number != 0) {
-                    context.getString(
-                        R.string.tv_show_item_season_number_episode_number,
-                        season.number,
-                        episode.number
-                    )
+                    context.getString(R.string.tv_show_item_season_number_episode_number, season.number, episode.number)
                 } else {
-                    context.getString(
-                        R.string.tv_show_item_episode_number,
-                        episode.number
-                    )
+                    context.getString(R.string.tv_show_item_episode_number, episode.number)
                 }
             }
         } ?: context.getString(R.string.tv_show_item_type)
-
         binding.tvTvShowTitle.text = tvShow.title
     }
 
@@ -326,27 +313,21 @@ class TvShowViewHolder(
 
     private fun displayGridTvItem(binding: ItemTvShowGridBinding) {
         binding.root.apply {
-            setOnClickListener {
-                checkProviderAndRun { // <-- LÓGICA APLICADA
-                    when (context.toActivity()?.getCurrentFragment()) {
-                        is GenreTvFragment -> findNavController().navigate(
-                            GenreTvFragmentDirections.actionGenreToTvShow(id = tvShow.id)
-                        )
-                        is PeopleTvFragment -> findNavController().navigate(
-                            PeopleTvFragmentDirections.actionPeopleToTvShow(id = tvShow.id)
-                        )
-                        is SearchTvFragment -> findNavController().navigate(
-                            SearchTvFragmentDirections.actionSearchToTvShow(id = tvShow.id)
-                        )
-                        is TvShowsTvFragment -> findNavController().navigate(
-                            TvShowsTvFragmentDirections.actionTvShowsToTvShow(id = tvShow.id)
-                        )
-                    }
+            // --- INICIO DE LA MODIFICACIÓN (PARA BÚSQUEDA NORMAL) ---
+            isFocusable = true
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
+                    (keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER || keyCode == android.view.KeyEvent.KEYCODE_ENTER)
+                ) {
+                    (bindingAdapter as? AppAdapter)?.onTvShowClickListener?.invoke(tvShow)
+                    return@setOnKeyListener true
                 }
+                return@setOnKeyListener false
             }
+            // --- FIN DE LA MODIFICACIÓN ---
+
             setOnLongClickListener {
-                ShowOptionsTvDialog(context, tvShow)
-                    .show()
+                ShowOptionsTvDialog(context, tvShow).show()
                 true
             }
             setOnFocusChangeListener { _, hasFocus ->
@@ -358,14 +339,13 @@ class TvShowViewHolder(
                 animation.fillAfter = true
             }
         }
-
+        // ... El resto del método para cargar imágenes y texto se mantiene exactamente igual
         Glide.with(context)
             .load(tvShow.poster)
             .fallback(R.drawable.glide_fallback_cover)
             .centerCrop()
             .transition(DrawableTransitionOptions.withCrossFade())
             .into(binding.ivTvShowPoster)
-
         binding.tvTvShowQuality.apply {
             text = tvShow.quality ?: ""
             visibility = when {
@@ -373,24 +353,15 @@ class TvShowViewHolder(
                 else -> View.VISIBLE
             }
         }
-
         binding.tvTvShowLastEpisode.text = tvShow.seasons.lastOrNull()?.let { season ->
             season.episodes.lastOrNull()?.let { episode ->
                 if (season.number != 0) {
-                    context.getString(
-                        R.string.tv_show_item_season_number_episode_number,
-                        season.number,
-                        episode.number
-                    )
+                    context.getString(R.string.tv_show_item_season_number_episode_number, season.number, episode.number)
                 } else {
-                    context.getString(
-                        R.string.tv_show_item_episode_number,
-                        episode.number
-                    )
+                    context.getString(R.string.tv_show_item_episode_number, episode.number)
                 }
             }
         } ?: context.getString(R.string.tv_show_item_type)
-
         binding.tvTvShowTitle.text = tvShow.title
     }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
@@ -71,6 +71,8 @@ import com.streamflixreborn.streamflix.utils.format
 import com.streamflixreborn.streamflix.utils.getCurrentFragment
 import com.streamflixreborn.streamflix.utils.toActivity
 import java.util.Locale
+import com.streamflixreborn.streamflix.utils.UserPreferences
+import com.streamflixreborn.streamflix.providers.Provider
 
 class TvShowViewHolder(
     private val _binding: ViewBinding
@@ -121,27 +123,30 @@ class TvShowViewHolder(
             is ContentTvShowRecommendationsTvBinding -> displayRecommendationsTv(_binding)
         }
     }
-
+    private fun checkProviderAndRun(action: () -> Unit) {
+        if (!tvShow.providerName.isNullOrBlank() && tvShow.providerName != UserPreferences.currentProvider?.name) {
+            Provider.providers.keys.find { it.name == tvShow.providerName }?.let {
+                UserPreferences.currentProvider = it
+            }
+        }
+        action()
+    }
 
     private fun displayMobileItem(binding: ItemTvShowMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is HomeMobileFragment -> findNavController().navigate(
-                        HomeMobileFragmentDirections.actionHomeToTvShow(
-                            id = tvShow.id
+                checkProviderAndRun { // <-- LÓGICA APLICADA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is HomeMobileFragment -> findNavController().navigate(
+                            HomeMobileFragmentDirections.actionHomeToTvShow(id = tvShow.id)
                         )
-                    )
-                    is MovieMobileFragment -> findNavController().navigate(
-                        MovieMobileFragmentDirections.actionMovieToTvShow(
-                            id = tvShow.id
+                        is MovieMobileFragment -> findNavController().navigate(
+                            MovieMobileFragmentDirections.actionMovieToTvShow(id = tvShow.id)
                         )
-                    )
-                    is TvShowMobileFragment -> findNavController().navigate(
-                        TvShowMobileFragmentDirections.actionTvShowToTvShow(
-                            id = tvShow.id
+                        is TvShowMobileFragment -> findNavController().navigate(
+                            TvShowMobileFragmentDirections.actionTvShowToTvShow(id = tvShow.id)
                         )
-                    )
+                    }
                 }
             }
             setOnLongClickListener {
@@ -188,22 +193,18 @@ class TvShowViewHolder(
     private fun displayTvItem(binding: ItemTvShowTvBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is HomeTvFragment -> findNavController().navigate(
-                        HomeTvFragmentDirections.actionHomeToTvShow(
-                            id = tvShow.id
+                checkProviderAndRun { // <-- LÓGICA APLICADA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is HomeTvFragment -> findNavController().navigate(
+                            HomeTvFragmentDirections.actionHomeToTvShow(id = tvShow.id)
                         )
-                    )
-                    is MovieTvFragment -> findNavController().navigate(
-                        MovieTvFragmentDirections.actionMovieToTvShow(
-                            id = tvShow.id
+                        is MovieTvFragment -> findNavController().navigate(
+                            MovieTvFragmentDirections.actionMovieToTvShow(id = tvShow.id)
                         )
-                    )
-                    is TvShowTvFragment -> findNavController().navigate(
-                        TvShowTvFragmentDirections.actionTvShowToTvShow(
-                            id = tvShow.id
+                        is TvShowTvFragment -> findNavController().navigate(
+                            TvShowTvFragmentDirections.actionTvShowToTvShow(id = tvShow.id)
                         )
-                    )
+                    }
                 }
             }
             setOnLongClickListener {
@@ -265,27 +266,21 @@ class TvShowViewHolder(
     private fun displayGridMobileItem(binding: ItemTvShowGridMobileBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is GenreMobileFragment -> findNavController().navigate(
-                        GenreMobileFragmentDirections.actionGenreToTvShow(
-                            id = tvShow.id
+                checkProviderAndRun { // <-- LÓGICA APLICADA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is GenreMobileFragment -> findNavController().navigate(
+                            GenreMobileFragmentDirections.actionGenreToTvShow(id = tvShow.id)
                         )
-                    )
-                    is PeopleMobileFragment -> findNavController().navigate(
-                        PeopleMobileFragmentDirections.actionPeopleToTvShow(
-                            id = tvShow.id
+                        is PeopleMobileFragment -> findNavController().navigate(
+                            PeopleMobileFragmentDirections.actionPeopleToTvShow(id = tvShow.id)
                         )
-                    )
-                    is SearchMobileFragment -> findNavController().navigate(
-                        SearchMobileFragmentDirections.actionSearchToTvShow(
-                            id = tvShow.id
+                        is SearchMobileFragment -> findNavController().navigate(
+                            SearchMobileFragmentDirections.actionSearchToTvShow(id = tvShow.id)
                         )
-                    )
-                    is TvShowsMobileFragment -> findNavController().navigate(
-                        TvShowsMobileFragmentDirections.actionTvShowsToTvShow(
-                            id = tvShow.id
+                        is TvShowsMobileFragment -> findNavController().navigate(
+                            TvShowsMobileFragmentDirections.actionTvShowsToTvShow(id = tvShow.id)
                         )
-                    )
+                    }
                 }
             }
             setOnLongClickListener {
@@ -332,27 +327,21 @@ class TvShowViewHolder(
     private fun displayGridTvItem(binding: ItemTvShowGridBinding) {
         binding.root.apply {
             setOnClickListener {
-                when (context.toActivity()?.getCurrentFragment()) {
-                    is GenreTvFragment -> findNavController().navigate(
-                        GenreTvFragmentDirections.actionGenreToTvShow(
-                            id = tvShow.id
+                checkProviderAndRun { // <-- LÓGICA APLICADA
+                    when (context.toActivity()?.getCurrentFragment()) {
+                        is GenreTvFragment -> findNavController().navigate(
+                            GenreTvFragmentDirections.actionGenreToTvShow(id = tvShow.id)
                         )
-                    )
-                    is PeopleTvFragment -> findNavController().navigate(
-                        PeopleTvFragmentDirections.actionPeopleToTvShow(
-                            id = tvShow.id
+                        is PeopleTvFragment -> findNavController().navigate(
+                            PeopleTvFragmentDirections.actionPeopleToTvShow(id = tvShow.id)
                         )
-                    )
-                    is SearchTvFragment -> findNavController().navigate(
-                        SearchTvFragmentDirections.actionSearchToTvShow(
-                            id = tvShow.id
+                        is SearchTvFragment -> findNavController().navigate(
+                            SearchTvFragmentDirections.actionSearchToTvShow(id = tvShow.id)
                         )
-                    )
-                    is TvShowsTvFragment -> findNavController().navigate(
-                        TvShowsTvFragmentDirections.actionTvShowsToTvShow(
-                            id = tvShow.id
+                        is TvShowsTvFragment -> findNavController().navigate(
+                            TvShowsTvFragmentDirections.actionTvShowsToTvShow(id = tvShow.id)
                         )
-                    )
+                    }
                 }
             }
             setOnLongClickListener {
@@ -548,13 +537,12 @@ class TvShowViewHolder(
         binding.tvTvShowOverview.text = tvShow.overview
 
         val episodeToWatch = tvShow.episodeToWatch
-
         binding.btnTvShowWatchEpisode.apply {
             setOnClickListener {
                 if (episodeToWatch == null) return@setOnClickListener
-
-                findNavController().navigate(
-                    TvShowMobileFragmentDirections.actionTvShowToPlayer(
+                checkProviderAndRun { // <-- LÓGICA APLICADA
+                    findNavController().navigate(
+                        TvShowMobileFragmentDirections.actionTvShowToPlayer(
                         id = episodeToWatch.id,
                         title = tvShow.title,
                         subtitle = episodeToWatch.season?.takeIf { it.number != 0 }?.let { season ->
@@ -593,7 +581,7 @@ class TvShowViewHolder(
                         ),
                     )
                 )
-            }
+            }}
 
             text = if (episodeToWatch != null) {
                 episodeToWatch.season?.takeIf { it.number != 0 }?.let { season ->
@@ -802,13 +790,12 @@ class TvShowViewHolder(
         binding.tvTvShowOverview.text = tvShow.overview
 
         val episodeToWatch = tvShow.episodeToWatch
-
         binding.btnTvShowWatchEpisode.apply {
             setOnClickListener {
                 if (episodeToWatch == null) return@setOnClickListener
-
-                findNavController().navigate(
-                    TvShowTvFragmentDirections.actionTvShowToPlayer(
+                checkProviderAndRun { // <-- LÓGICA APLICADA
+                    findNavController().navigate(
+                        TvShowTvFragmentDirections.actionTvShowToPlayer(
                         id = episodeToWatch.id,
                         title = tvShow.title,
                         subtitle = episodeToWatch.season?.takeIf { it.number != 0 }?.let { season ->
@@ -848,7 +835,7 @@ class TvShowViewHolder(
                     )
                 )
             }
-
+            }
             text = if (episodeToWatch != null) {
                 episodeToWatch.season?.takeIf { it.number != 0 }?.let { season ->
                     context.getString(

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchMobileFragment.kt
@@ -231,11 +231,12 @@ class SearchMobileFragment : Fragment() {
 
         providerResults.forEach { providerResult ->
             val headerTitle = when (val state = providerResult.state) {
-                is ProviderResult.State.Loading -> "${providerResult.provider.name} - Buscando..."
-                is ProviderResult.State.Error -> "${providerResult.provider.name} - Error"
+                is ProviderResult.State.Loading -> "${providerResult.provider.name} - ${getString(R.string.searching)}"
+                is ProviderResult.State.Error -> "${providerResult.provider.name} - ${getString(R.string.search_error)}"
                 is ProviderResult.State.Success -> {
                     val count = state.results.size
-                    "${providerResult.provider.name} - $count ${if (count == 1) "resultado" else "resultados"}"
+                    val resultText = if (count == 1) getString(R.string.result) else getString(R.string.results)
+                    "${providerResult.provider.name} - $count $resultText"
                 }
             }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchMobileFragment.kt
@@ -19,11 +19,13 @@ import com.streamflixreborn.streamflix.R
 import com.streamflixreborn.streamflix.adapters.AppAdapter
 import com.streamflixreborn.streamflix.database.AppDatabase
 import com.streamflixreborn.streamflix.databinding.FragmentSearchMobileBinding
+import com.streamflixreborn.streamflix.models.Category
 import com.streamflixreborn.streamflix.models.Genre
 import com.streamflixreborn.streamflix.models.Movie
 import com.streamflixreborn.streamflix.models.TvShow
 import com.streamflixreborn.streamflix.ui.SpacingItemDecoration
 import com.streamflixreborn.streamflix.utils.CacheUtils
+import com.streamflixreborn.streamflix.utils.UserPreferences // <-- IMPORT AÑADIDO
 import com.streamflixreborn.streamflix.utils.VoiceRecognitionHelper
 import com.streamflixreborn.streamflix.utils.dp
 import com.streamflixreborn.streamflix.utils.hideKeyboard
@@ -60,8 +62,9 @@ class SearchMobileFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.state.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { state ->
+                // ========= BLOQUE WHEN MODIFICADO =========
                 when (state) {
-                    SearchViewModel.State.Searching -> {
+                    is State.Searching, is State.GlobalSearching -> {
                         binding.isLoading.apply {
                             root.visibility = View.VISIBLE
                             pbIsLoading.visibility = View.VISIBLE
@@ -71,13 +74,17 @@ class SearchMobileFragment : Fragment() {
                             appAdapter = it
                         }
                     }
-                    SearchViewModel.State.SearchingMore -> appAdapter.isLoading = true
-                    is SearchViewModel.State.SuccessSearching -> {
+                    is State.SearchingMore -> appAdapter.isLoading = true
+                    is State.SuccessSearching -> {
                         displaySearch(state.results, state.hasMore)
                         appAdapter.isLoading = false
                         binding.isLoading.root.visibility = View.GONE
                     }
-                    is SearchViewModel.State.FailedSearching -> {
+                    is State.SuccessGlobalSearching -> {
+                        displayGlobalSearch(state.providerResults)
+                        binding.isLoading.root.visibility = View.GONE
+                    }
+                    is State.FailedSearching -> {
                         val code = (state.error as? retrofit2.HttpException)?.code()
                         if (code == 409 && !hasAutoCleared409) {
                             hasAutoCleared409 = true
@@ -108,6 +115,7 @@ class SearchMobileFragment : Fragment() {
                         }
                     }
                 }
+                // ===========================================
             }
         }
     }
@@ -118,30 +126,31 @@ class SearchMobileFragment : Fragment() {
         _binding = null
     }
 
-
     private fun initializeSearch() {
         binding.etSearch.apply {
+            // ========= LÓGICA DE BÚSQUEDA MODIFICADA =========
             setOnEditorActionListener { _, actionId, _ ->
-                when (actionId) {
-                    EditorInfo.IME_ACTION_GO,
-                    EditorInfo.IME_ACTION_SEARCH,
-                    EditorInfo.IME_ACTION_SEND,
-                    EditorInfo.IME_ACTION_NEXT,
-                    EditorInfo.IME_ACTION_DONE -> {
-                        viewModel.search(text.toString())
-                        hideKeyboard()
-                        true
+                if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                    val query = binding.etSearch.text.toString()
+                    hideKeyboard()
+
+                    if (binding.swGlobalSearch.isChecked) {
+                        val currentLanguage = UserPreferences.currentProvider?.language ?: "es"
+                        viewModel.searchGlobal(query, currentLanguage)
+                    } else {
+                        viewModel.search(query)
                     }
-                    else -> false
+                    return@setOnEditorActionListener true
                 }
+                return@setOnEditorActionListener false
             }
+            // =================================================
 
             addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(s: Editable?) {
                     if(s.isNullOrBlank()){
                         binding.etSearch.hint = getString(R.string.search_input_hint)
                     }
-
                 }
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
@@ -198,7 +207,6 @@ class SearchMobileFragment : Fragment() {
                 SpacingItemDecoration(10.dp(requireContext()))
             )
         }
-
     }
 
     private fun displaySearch(list: List<AppAdapter.Item>, hasMore: Boolean) {
@@ -216,4 +224,42 @@ class SearchMobileFragment : Fragment() {
             appAdapter.setOnLoadMoreListener(null)
         }
     }
+
+    // ========= NUEVA FUNCIÓN PARA MOSTRAR RESULTADOS GLOBALES =========
+    private fun displayGlobalSearch(providerResults: List<ProviderResult>) {
+        val allItems = mutableListOf<AppAdapter.Item>()
+
+        providerResults.forEach { providerResult ->
+            val headerTitle = when (val state = providerResult.state) {
+                is ProviderResult.State.Loading -> "${providerResult.provider.name} - Buscando..."
+                is ProviderResult.State.Error -> "${providerResult.provider.name} - Error"
+                is ProviderResult.State.Success -> {
+                    val count = state.results.size
+                    "${providerResult.provider.name} - $count ${if (count == 1) "resultado" else "resultados"}"
+                }
+            }
+
+            val header = Category(
+                name = headerTitle,
+                list = emptyList()
+            ).apply {
+                itemType = AppAdapter.Type.CATEGORY_MOBILE_ITEM
+            }
+            allItems.add(header)
+
+            if (providerResult.state is ProviderResult.State.Success) {
+                val results = providerResult.state.results.onEach {
+                    when (it) {
+                        is Movie -> it.itemType = AppAdapter.Type.MOVIE_GRID_MOBILE_ITEM
+                        is TvShow -> it.itemType = AppAdapter.Type.TV_SHOW_GRID_MOBILE_ITEM
+                    }
+                }
+                allItems.addAll(results)
+            }
+        }
+
+        appAdapter.submitList(allItems)
+        appAdapter.setOnLoadMoreListener(null) // Desactivamos la carga infinita en la búsqueda global
+    }
+    // ================================================================
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
@@ -44,7 +44,7 @@ class SearchTvFragment : Fragment() {
     private val appAdapter by lazy {
         AppAdapter().apply {
             onMovieClickListener = { movie ->
-                // Esta es la acción que se ejecutará al hacer clic en una película
+
                 if (movie.providerName != UserPreferences.currentProvider?.name) {
                     UserPreferences.currentProvider = Provider.providers.keys.find { it.name == movie.providerName }
                     Toast.makeText(requireContext(), "Cambiando a ${movie.providerName}", Toast.LENGTH_SHORT).show()
@@ -54,7 +54,7 @@ class SearchTvFragment : Fragment() {
                 )
             }
             onTvShowClickListener = { tvShow ->
-                // Esta es la acción que se ejecutará al hacer clic en una serie
+
                 if (tvShow.providerName != UserPreferences.currentProvider?.name) {
                     UserPreferences.currentProvider = Provider.providers.keys.find { it.name == tvShow.providerName }
                     Toast.makeText(requireContext(), "Cambiando a ${tvShow.providerName}", Toast.LENGTH_SHORT).show()
@@ -65,7 +65,7 @@ class SearchTvFragment : Fragment() {
             }
         }
     }
-    // --- FIN DE LA MODIFICACIÓN ---
+
     private lateinit var voiceHelper: VoiceRecognitionHelper
 
     override fun onCreateView(
@@ -82,8 +82,7 @@ class SearchTvFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.state.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { state ->
-                // --- INICIO DE LA MODIFICACIÓN #2 ---
-                // Reemplazamos el 'when' incompleto por uno exhaustivo
+
                 when (state) {
                     is State.Searching, is State.GlobalSearching -> {
                         binding.isLoading.apply {
@@ -91,7 +90,7 @@ class SearchTvFragment : Fragment() {
                             pbIsLoading.visibility = View.VISIBLE
                             gIsLoadingRetry.visibility = View.GONE
                         }
-                        // Usamos el appAdapter que ya tiene los listeners
+
                         binding.vgvSearch.adapter = appAdapter
                     }
                     is State.SearchingMore -> appAdapter.isLoading = true
@@ -137,7 +136,6 @@ class SearchTvFragment : Fragment() {
                         }
                     }
                 }
-                // --- FIN DE LA MODIFICACIÓN #2 ---
             }
         }
     }
@@ -242,7 +240,6 @@ class SearchTvFragment : Fragment() {
     }
 
     private fun displayGlobalSearch(providerResults: List<ProviderResult>) {
-        // --- LÓGICA COMPLETAMENTE REESCRITA PARA EL PATRÓN DE FILAS ---
         val categories = providerResults.map { providerResult ->
             val headerTitle = when (val state = providerResult.state) {
                 is ProviderResult.State.Loading -> "${providerResult.provider.name} - Buscando..."

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
@@ -47,7 +47,7 @@ class SearchTvFragment : Fragment() {
 
                 if (movie.providerName != UserPreferences.currentProvider?.name) {
                     UserPreferences.currentProvider = Provider.providers.keys.find { it.name == movie.providerName }
-                    Toast.makeText(requireContext(), "Cambiando a ${movie.providerName}", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.switching_to_provider, movie.providerName), Toast.LENGTH_SHORT).show()
                 }
                 findNavController().navigate(
                     SearchTvFragmentDirections.actionSearchToMovie(id = movie.id)
@@ -57,7 +57,7 @@ class SearchTvFragment : Fragment() {
 
                 if (tvShow.providerName != UserPreferences.currentProvider?.name) {
                     UserPreferences.currentProvider = Provider.providers.keys.find { it.name == tvShow.providerName }
-                    Toast.makeText(requireContext(), "Cambiando a ${tvShow.providerName}", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.switching_to_provider, tvShow.providerName), Toast.LENGTH_SHORT).show()
                 }
                 findNavController().navigate(
                     SearchTvFragmentDirections.actionSearchToTvShow(id = tvShow.id)
@@ -242,11 +242,12 @@ class SearchTvFragment : Fragment() {
     private fun displayGlobalSearch(providerResults: List<ProviderResult>) {
         val categories = providerResults.map { providerResult ->
             val headerTitle = when (val state = providerResult.state) {
-                is ProviderResult.State.Loading -> "${providerResult.provider.name} - Buscando..."
-                is ProviderResult.State.Error -> "${providerResult.provider.name} - Error"
+                is ProviderResult.State.Loading -> "${providerResult.provider.name} - ${getString(R.string.searching)}"
+                is ProviderResult.State.Error -> "${providerResult.provider.name} - ${getString(R.string.search_error)}"
                 is ProviderResult.State.Success -> {
                     val count = state.results.size
-                    "${providerResult.provider.name} - $count ${if (count == 1) "resultado" else "resultados"}"
+                    val resultText = if (count == 1) getString(R.string.result) else getString(R.string.results)
+                    "${providerResult.provider.name} - $count $resultText"
                 }
             }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
@@ -19,10 +19,12 @@ import com.streamflixreborn.streamflix.R
 import com.streamflixreborn.streamflix.adapters.AppAdapter
 import com.streamflixreborn.streamflix.database.AppDatabase
 import com.streamflixreborn.streamflix.databinding.FragmentSearchTvBinding
+import com.streamflixreborn.streamflix.models.Category
 import com.streamflixreborn.streamflix.models.Genre
 import com.streamflixreborn.streamflix.models.Movie
 import com.streamflixreborn.streamflix.models.TvShow
 import com.streamflixreborn.streamflix.utils.CacheUtils
+import com.streamflixreborn.streamflix.utils.UserPreferences
 import com.streamflixreborn.streamflix.utils.VoiceRecognitionHelper
 import com.streamflixreborn.streamflix.utils.hideKeyboard
 import com.streamflixreborn.streamflix.utils.viewModelsFactory
@@ -31,7 +33,6 @@ import kotlinx.coroutines.launch
 class SearchTvFragment : Fragment() {
 
     private var hasAutoCleared409: Boolean = false
-
     private var _binding: FragmentSearchTvBinding? = null
     private val binding get() = _binding!!
 
@@ -39,13 +40,10 @@ class SearchTvFragment : Fragment() {
     private val viewModel by viewModelsFactory { SearchViewModel(database) }
 
     private var appAdapter = AppAdapter()
-
     private lateinit var voiceHelper: VoiceRecognitionHelper
 
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSearchTvBinding.inflate(inflater, container, false)
         return binding.root
@@ -59,39 +57,39 @@ class SearchTvFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.state.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect { state ->
                 when (state) {
-                    SearchViewModel.State.Searching -> {
+                    is State.Searching, is State.GlobalSearching -> {
                         binding.isLoading.apply {
                             root.visibility = View.VISIBLE
                             pbIsLoading.visibility = View.VISIBLE
                             gIsLoadingRetry.visibility = View.GONE
                         }
-                        binding.vgvSearch.adapter = AppAdapter().also {
-                            appAdapter = it
-                        }
+                        binding.vgvSearch.adapter = AppAdapter().also { appAdapter = it }
                     }
-                    SearchViewModel.State.SearchingMore -> appAdapter.isLoading = true
-                    is SearchViewModel.State.SuccessSearching -> {
+                    is State.SearchingMore -> appAdapter.isLoading = true
+                    is State.SuccessSearching -> {
                         displaySearch(state.results, state.hasMore)
                         appAdapter.isLoading = false
-                        binding.etSearch.nextFocusDownId = binding.vgvSearch.id
                         binding.vgvSearch.visibility = View.VISIBLE
                         binding.isLoading.root.visibility = View.GONE
                     }
-                    is SearchViewModel.State.FailedSearching -> {
+                    is State.SuccessGlobalSearching -> {
+                        displayGlobalSearch(state.providerResults)
+                        appAdapter.isLoading = false
+                        binding.vgvSearch.visibility = View.VISIBLE
+                        binding.isLoading.root.visibility = View.GONE
+                    }
+                    is State.FailedSearching -> {
+                        // (Mantenemos la lógica de errores igual)
                         val code = (state.error as? retrofit2.HttpException)?.code()
                         if (code == 409 && !hasAutoCleared409) {
                             hasAutoCleared409 = true
                             CacheUtils.clearAppCache(requireContext())
-                            android.widget.Toast.makeText(requireContext(), getString(com.streamflixreborn.streamflix.R.string.clear_cache_done_409), android.widget.Toast.LENGTH_SHORT).show()
+                            Toast.makeText(requireContext(), getString(R.string.clear_cache_done_409), Toast.LENGTH_SHORT).show()
                             if (appAdapter.isLoading) appAdapter.isLoading = false
                             viewModel.search(viewModel.query)
                             return@collect
                         }
-                        Toast.makeText(
-                            requireContext(),
-                            state.error.message ?: "",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        Toast.makeText(requireContext(), state.error.message ?: "", Toast.LENGTH_SHORT).show()
                         if (appAdapter.isLoading) {
                             appAdapter.isLoading = false
                         } else {
@@ -101,7 +99,7 @@ class SearchTvFragment : Fragment() {
                                 btnIsLoadingRetry.setOnClickListener { viewModel.search(viewModel.query) }
                                 btnIsLoadingClearCache.setOnClickListener {
                                     CacheUtils.clearAppCache(requireContext())
-                                    android.widget.Toast.makeText(requireContext(), getString(com.streamflixreborn.streamflix.R.string.clear_cache_done), android.widget.Toast.LENGTH_SHORT).show()
+                                    Toast.makeText(requireContext(), getString(R.string.clear_cache_done), Toast.LENGTH_SHORT).show()
                                     viewModel.search(viewModel.query)
                                 }
                                 binding.vgvSearch.visibility = View.INVISIBLE
@@ -121,35 +119,33 @@ class SearchTvFragment : Fragment() {
         _binding = null
     }
 
-
     private fun initializeSearch() {
         binding.etSearch.apply {
             setOnEditorActionListener { _, actionId, _ ->
-                when (actionId) {
-                    EditorInfo.IME_ACTION_GO,
-                    EditorInfo.IME_ACTION_SEARCH,
-                    EditorInfo.IME_ACTION_SEND,
-                    EditorInfo.IME_ACTION_NEXT,
-                    EditorInfo.IME_ACTION_DONE -> {
-                        viewModel.search(text.toString())
-                        hideKeyboard()
-                        true
+                if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                    val query = text.toString()
+                    hideKeyboard()
+
+                    if (binding.swGlobalSearch.isChecked) {
+                        val currentLanguage = UserPreferences.currentProvider?.language ?: "es"
+                        viewModel.searchGlobal(query, currentLanguage)
+                    } else {
+                        viewModel.search(query)
                     }
-                    else -> false
+                    return@setOnEditorActionListener true
                 }
+                return@setOnEditorActionListener false
             }
 
             addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(s: Editable?) {
-                   if(s.isNullOrBlank()){
-                       binding.etSearch.hint = getString(R.string.search_input_hint)
-                   }
-
+                    if (s.isNullOrBlank()) {
+                        binding.etSearch.hint = getString(R.string.search_input_hint)
+                    }
                 }
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             })
-
         }
 
         val blink = AlphaAnimation(1f, 0.3f).apply {
@@ -178,16 +174,9 @@ class SearchTvFragment : Fragment() {
 
         binding.btnSearchVoice.apply {
             requestFocus()
-            visibility =
-                if (voiceHelper.isAvailable()) View.VISIBLE else View.GONE
-
-            setOnClickListener {
-                if (!voiceHelper.isListening) {
-                    voiceHelper.startWithPermissionCheck()
-                }
-            }
+            visibility = if (voiceHelper.isAvailable()) View.VISIBLE else View.GONE
+            setOnClickListener { if (!voiceHelper.isListening) voiceHelper.startWithPermissionCheck() }
         }
-
 
         binding.btnSearchClear.setOnClickListener {
             binding.etSearch.setText("")
@@ -199,19 +188,14 @@ class SearchTvFragment : Fragment() {
             adapter = appAdapter.apply {
                 stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
             }
-            setItemSpacing(requireContext().resources.getDimension(R.dimen.search_spacing).toInt())
+            setItemSpacing(resources.getDimension(R.dimen.search_spacing).toInt())
         }
 
         binding.root.requestFocus()
     }
 
     private fun displaySearch(list: List<AppAdapter.Item>, hasMore: Boolean) {
-        binding.vgvSearch.apply {
-            setNumColumns(
-                if (viewModel.query == "") 5
-                else 6
-            )
-        }
+        binding.vgvSearch.setNumColumns(if (viewModel.query == "") 5 else 6)
 
         appAdapter.submitList(list.onEach {
             when (it) {
@@ -226,5 +210,34 @@ class SearchTvFragment : Fragment() {
         } else {
             appAdapter.setOnLoadMoreListener(null)
         }
+    }
+
+    private fun displayGlobalSearch(providerResults: List<ProviderResult>) {
+        // --- LÓGICA COMPLETAMENTE REESCRITA PARA EL PATRÓN DE FILAS ---
+        val categories = providerResults.map { providerResult ->
+            val headerTitle = when (val state = providerResult.state) {
+                is ProviderResult.State.Loading -> "${providerResult.provider.name} - Buscando..."
+                is ProviderResult.State.Error -> "${providerResult.provider.name} - Error"
+                is ProviderResult.State.Success -> {
+                    val count = state.results.size
+                    "${providerResult.provider.name} - $count ${if (count == 1) "resultado" else "resultados"}"
+                }
+            }
+
+            val items = (providerResult.state as? ProviderResult.State.Success)?.results?.onEach {
+                when (it) {
+                    is Movie -> it.itemType = AppAdapter.Type.MOVIE_TV_ITEM
+                    is TvShow -> it.itemType = AppAdapter.Type.TV_SHOW_TV_ITEM
+                }
+            } ?: emptyList()
+
+            Category(name = headerTitle, list = items).apply {
+                itemType = AppAdapter.Type.CATEGORY_TV_ITEM
+            }
+        }
+
+        binding.vgvSearch.setNumColumns(1) // La lista de categorías es una sola columna vertical
+        appAdapter.submitList(categories)
+        appAdapter.setOnLoadMoreListener(null)
     }
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/models/Movie.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/models/Movie.kt
@@ -24,6 +24,9 @@ class Movie(
     var banner: String? = null,
 
     @Ignore
+    var providerName: String? = null,
+
+    @Ignore
     val genres: List<Genre> = listOf(),
     @Ignore
     val directors: List<People> = listOf(),
@@ -89,6 +92,7 @@ class Movie(
         rating,
         poster,
         banner,
+        providerName,
         genres,
         directors,
         cast,

--- a/app/src/main/java/com/streamflixreborn/streamflix/models/TvShow.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/models/TvShow.kt
@@ -22,6 +22,8 @@ class TvShow(
     var banner: String? = null,
 
     @Ignore
+    var providerName: String? = null,
+    @Ignore
     val seasons: List<Season> = listOf(),
     @Ignore
     val genres: List<Genre> = listOf(),
@@ -96,6 +98,7 @@ class TvShow(
         rating,
         poster,
         banner,
+        providerName,
         seasons,
         genres,
         directors,

--- a/app/src/main/res/layout/fragment_search_mobile.xml
+++ b/app/src/main/res/layout/fragment_search_mobile.xml
@@ -78,6 +78,16 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/sw_global_search"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Búsqueda Global"
+        app:layout_constraintEnd_toEndOf="@id/cl_search"
+        app:layout_constraintStart_toStartOf="@id/cl_search"
+        app:layout_constraintTop_toBottomOf="@id/cl_search" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_search"
         android:layout_width="0dp"
@@ -91,7 +101,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cl_search"
+        app:layout_constraintTop_toBottomOf="@id/sw_global_search"
         app:spanCount="3"
         tools:listitem="@layout/item_movie_mobile" />
 

--- a/app/src/main/res/layout/fragment_search_mobile.xml
+++ b/app/src/main/res/layout/fragment_search_mobile.xml
@@ -83,7 +83,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="Búsqueda Global"
+        android:text="@string/global_search"
         app:layout_constraintEnd_toEndOf="@id/cl_search"
         app:layout_constraintStart_toStartOf="@id/cl_search"
         app:layout_constraintTop_toBottomOf="@id/cl_search" />

--- a/app/src/main/res/layout/fragment_search_tv.xml
+++ b/app/src/main/res/layout/fragment_search_tv.xml
@@ -94,7 +94,7 @@
         android:nextFocusDown="@id/vgv_search"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
-        android:text="Búsqueda Global"
+        android:text="@string/global_search"
         android:textColor="@android:color/white"
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="@id/cl_search"

--- a/app/src/main/res/layout/fragment_search_tv.xml
+++ b/app/src/main/res/layout/fragment_search_tv.xml
@@ -34,7 +34,7 @@
             android:inputType="text"
             android:maxLines="1"
             android:nextFocusRight="@+id/btn_search_clear"
-            android:nextFocusDown="@id/vgv_search"
+            android:nextFocusDown="@id/sw_global_search"
             android:padding="14dp"
             android:textSize="16sp"
             app:layout_constraintEnd_toStartOf="@+id/btn_search_clear"
@@ -84,6 +84,23 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/sw_global_search"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:nextFocusDown="@id/vgv_search"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="Búsqueda Global"
+        android:textColor="@android:color/white"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="@id/cl_search"
+        app:layout_constraintStart_toStartOf="@id/cl_search"
+        app:layout_constraintTop_toBottomOf="@id/cl_search"/>
+
     <androidx.leanback.widget.VerticalGridView
         android:id="@+id/vgv_search"
         android:layout_width="0dp"
@@ -91,14 +108,12 @@
         android:layout_marginTop="16dp"
         android:clipChildren="false"
         android:clipToPadding="false"
+        android:descendantFocusability="afterDescendants"
         android:padding="16dp"
-        app:focusOutEnd="true"
-        app:focusOutFront="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cl_search"
-        app:numberOfColumns="6"
+        app:layout_constraintTop_toBottomOf="@id/sw_global_search"
         tools:listitem="@layout/item_movie_tv" />
 
     <include

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -31,6 +31,12 @@
 	<string name="main_menu_settings">الإعدادات</string>
 
 	<string name="search_input_hint">ابحث عن الأفلام أو المسلسلات</string>
+	<string name="global_search">بحث شامل</string>
+	<string name="searching">جاري البحث...</string>
+	<string name="search_error">خطأ</string>
+	<string name="result">نتيجة</string>
+	<string name="results">نتائج</string>
+	<string name="switching_to_provider">التبديل إلى %s</string>
 
 	<string name="home_swiper_watch_now">شاهد الآن</string>
 	<string name="home_continue_watching">متابعة المشاهدة</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -31,6 +31,12 @@
     <string name="main_menu_settings">Einstellungen</string>
 
     <string name="search_input_hint">Filme / Serien suchen</string>
+    <string name="global_search">Globale Suche</string>
+    <string name="searching">Suche läuft...</string>
+    <string name="search_error">Fehler</string>
+    <string name="result">Ergebnis</string>
+    <string name="results">Ergebnisse</string>
+    <string name="switching_to_provider">Wechseln zu %s</string>
 
     <string name="home_swiper_watch_now">Ansehen</string>
     <string name="home_continue_watching">Weiterschauen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,6 +25,12 @@
     <string name="main_menu_tv_shows">Series</string>
     <string name="main_menu_settings">Ajustes</string>
     <string name="search_input_hint">Buscar película, serie</string>
+    <string name="global_search">Búsqueda global</string>
+    <string name="searching">Buscando...</string>
+    <string name="search_error">Error</string>
+    <string name="result">Resultado</string>
+    <string name="results">Resultados</string>
+    <string name="switching_to_provider">Cambiando a %s</string>
     <string name="home_swiper_watch_now">Ver ahora</string>
     <string name="home_continue_watching">Continuar viendo</string>
     <string name="home_favorite_movies">Películas favoritas</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -30,6 +30,12 @@
     <string name="main_menu_settings">Impostazioni</string>
 
     <string name="search_input_hint">Cerca film, serie TV</string>
+    <string name="global_search">Ricerca globale</string>
+    <string name="searching">Ricerca in corso...</string>
+    <string name="search_error">Errore</string>
+    <string name="result">Risultato</string>
+    <string name="results">Risultati</string>
+    <string name="switching_to_provider">Passando a %s</string>
 
     <string name="home_swiper_watch_now">Guarda Ora</string>
     <string name="home_continue_watching">Continua a guardare</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,12 @@
     <string name="main_menu_settings">Settings</string>
 
     <string name="search_input_hint">Search movies, TV shows</string>
+    <string name="global_search">Global search</string>
+    <string name="searching">Searching...</string>
+    <string name="search_error">Error</string>
+    <string name="result">Result</string>
+    <string name="results">Results</string>
+    <string name="switching_to_provider">Switching to %s</string>
 
     <string name="home_swiper_watch_now">Watch Now</string>
     <string name="home_continue_watching">Continue Watching</string>


### PR DESCRIPTION
feat(search): Implementation of Global Search and Automatic Provider Switching

Description:
This Pull Request introduces Global Search functionality, which allows users to search for content simultaneously across all available providers for the app's current language, rather than just the active provider.

It also significantly improves the user experience by implementing automatic provider switching when selecting a global search result.

Main Changes:
Global Search Functionality:

A "Global Search" toggle has been added to the search screens for both Mobile and TV.

The SearchViewModel has been refactored to support parallel searches across multiple providers and manage the corresponding statuses (GlobalSearching, SuccessGlobalSearching).

Results are intelligently sorted, showing providers with found content first.

Automatic Provider Switching:

When clicking on a global search result, the app now automatically switches to the content's source provider before navigating to the details screen.

This ensures that all subsequent actions (such as retrieving sources) work seamlessly and transparently for the user.

The data models (Movie, TvShow) have been updated to associate each result with its source provider.

User Interface (UI) Adaptations:

Mobile: Global results are visually grouped by provider, with a header indicating the provider name and the number of results.

TV: The results view has been redesigned with a vertical row format, where each row represents a provider and its content. This design improves D-pad navigation.

Refactoring and Centralization (TV):

Navigation logic and event handling (clicks and D-pad presses) for search results have been centralized in the TV version.

setOnKeyListener is used to capture the "Enter" action on the D-pad, invoking centralized listeners in the SearchTvFragment.

This refactoring simplifies the code in ViewHolders, reduces duplication, and ensures that the provider switching logic works consistently across all views, including nested lists.