### PR TITLE
Sql Lite Chunk search

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/database/dao/EpisodeDao.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/database/dao/EpisodeDao.kt
@@ -59,6 +59,8 @@ interface EpisodeDao {
 
     @Query("SELECT * FROM episodes WHERE id IN (:ids)")
     fun getByIdsAsFlow(ids: List<String>): Flow<List<Episode>>
+    @Query("SELECT * FROM episodes WHERE season = :seasonId")
+    fun getBySeasonIdAsFlow(seasonId: String): Flow<List<Episode>>
 
     @Query("SELECT COUNT(id) > 0 FROM episodes WHERE tvShow = :tvShowId AND lastEngagementTimeUtcMillis IS NOT NULL")
     fun hasAnyWatchHistoryForTvShow(tvShowId: String): Boolean

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/season/SeasonViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/season/SeasonViewModel.kt
@@ -33,11 +33,11 @@ class SeasonViewModel(
         _state.transformLatest { state ->
             when (state) {
                 is State.SuccessLoadingEpisodes -> {
-                    database.episodeDao().getByIdsAsFlow(state.episodes.map { it.id })
+                    database.episodeDao()
+                        .getBySeasonIdAsFlow(seasonId)
                         .collect { emit(it) }
                 }
-
-                else -> emit(emptyList<Episode>())
+                else -> emit(emptyList())
             }
         },
         database.tvShowDao().getByIdAsFlow(tvShowId),
@@ -45,6 +45,7 @@ class SeasonViewModel(
     ) { state, episodesDb, tvShow, season ->
         season?.number?.let { seasonNumber = it }
         tvShow?.title?.let { tvShowTitle = it }
+
         when (state) {
             is State.SuccessLoadingEpisodes -> {
                 State.SuccessLoadingEpisodes(
@@ -53,9 +54,9 @@ class SeasonViewModel(
                             ?.takeIf { !episode.isSame(it) }
                             ?.let { episode.copy().merge(it) }
                             ?: episode
-                    }.onEach { episode ->
-                        episode.tvShow = tvShow
-                        episode.season = season
+                    }.onEach {
+                        it.tvShow = tvShow
+                        it.season = season
                     }
                 )
             }
@@ -80,13 +81,13 @@ class SeasonViewModel(
         try {
             val episodes = UserPreferences.currentProvider!!.getEpisodesBySeason(seasonId)
             val ids = episodes.map { it.id }
-            ids.chunked(900).forEach { chunk ->
+            val episodeMap = episodes.associateBy { it.id }
+
+            ids.chunked(400).forEach { chunk ->
                 database.episodeDao()
-                    .getByIdsAsFlow(chunk)
-                    .first()
+                    .getByIds(chunk)
                     .forEach { episodeDb ->
-                        episodes.find { it.id == episodeDb.id }
-                            ?.merge(episodeDb)
+                        episodeMap[episodeDb.id]?.merge(episodeDb)
                     }
             }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/tv_show/TvShowViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/tv_show/TvShowViewModel.kt
@@ -194,17 +194,22 @@ class TvShowViewModel(id: String, private val database: AppDatabase) : ViewModel
 
         try {
             val episodes = UserPreferences.currentProvider!!.getEpisodesBySeason(season.id)
+            val ids = episodes.map { it.id }
+            val episodeMap = episodes.associateBy { it.id }
 
+            ids.chunked(400).forEach { chunk ->
+                database.episodeDao()
+                    .getByIds(chunk)
+                    .forEach { episodeDb ->
+                        episodeMap[episodeDb.id]?.merge(episodeDb)
+                    }
+            }
 
-            database.episodeDao().getByIdsAsFlow(episodes.map { it.id }).first()
-                .forEach { episodeDb ->
-                    episodes.find { it.id == episodeDb.id }
-                        ?.merge(episodeDb)
-                }
-            episodes.onEach { episode ->
+            episodes.forEach { episode ->
                 episode.tvShow = tvShow
                 episode.season = season
             }
+
             database.episodeDao().insertAll(episodes)
 
             _seasonState.emit(SeasonState.SuccessLoading(tvShow, season, episodes))


### PR DESCRIPTION
chunk dao search for episodes to 900 since android <= 9 has a 999 sqllite limit.

In AnimeFLV provider for example when opening an anime with 1000+ episodes it throws error "SQLite error: too many arguments for select (?,?,?,?,…)". This fixes it