### PR TITLE
fix(mobile): register intent filter for streamflix://resolve

### DIFF
--- a/app/src/main/mobile/AndroidManifest.xml
+++ b/app/src/main/mobile/AndroidManifest.xml
@@ -51,6 +51,12 @@
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="streamflix" android:host="resolve"/>
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
## Current behavior

Currently, the mobile version of the app does not react to `streamflix://resolve` links (from QR codes on TV) scanned with an external camera app. Users have to manually navigate through the settings menu to use the internal QR scanner.

The problem only occurs in the *only-mobile* layout.

## Expected Behavior

Scanning the QR code with a camera app should automatically trigger the Android system to open the Streamflix app and navigate to the captcha resolving activity.

## Changes

I added the missing <intent-filter> for the streamflix scheme to the AndroidManifest.xml within the mobile source set.

