### PR TITLE
Fix stale player header when opening a different series episode

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
@@ -575,10 +575,12 @@ class PlayerMobileFragment : Fragment() {
         when (val type = args.videoType) {
             is Video.Type.Episode -> {
                 if (EpisodeManager.listIsEmpty(type)) {
+                    EpisodeManager.clearEpisodes()
                     lifecycleScope.launch(Dispatchers.IO) {
                         EpisodeManager.addEpisodesFromDb(type, database)
                         withContext(Dispatchers.Main) {
                             EpisodeManager.setCurrentEpisode(type)
+                            updatePlayerHeader(type)
                             setupEpisodeNavigationButtons()
                         }
                     }
@@ -1124,7 +1126,9 @@ class PlayerMobileFragment : Fragment() {
     }
 
     private fun currentVideoTypeForUi(): Video.Type = when (val type = args.videoType) {
-        is Video.Type.Episode -> EpisodeManager.getCurrentEpisode() ?: type
+        is Video.Type.Episode -> EpisodeManager.getCurrentEpisode()
+            ?.takeIf { currentEpisode -> currentEpisode.id == type.id }
+            ?: type
         is Video.Type.Movie -> type
     }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -718,10 +718,12 @@ class PlayerTvFragment : Fragment() {
                 is Video.Type.Episode -> {
 
                     if (EpisodeManager.listIsEmpty(type)) {
+                        EpisodeManager.clearEpisodes()
                         lifecycleScope.launch(Dispatchers.IO) {
                             EpisodeManager.addEpisodesFromDb(type, database)
                             withContext(Dispatchers.Main) {
                                 EpisodeManager.setCurrentEpisode(type)
+                                updatePlayerHeader(type)
                                 setupEpisodeNavigationButtons()
                             }
                         }
@@ -1283,7 +1285,9 @@ class PlayerTvFragment : Fragment() {
         }
 
         private fun currentVideoTypeForUi(): Video.Type = when (val type = args.videoType) {
-            is Video.Type.Episode -> EpisodeManager.getCurrentEpisode() ?: type
+            is Video.Type.Episode -> EpisodeManager.getCurrentEpisode()
+                ?.takeIf { currentEpisode -> currentEpisode.id == type.id }
+                ?: type
             is Video.Type.Movie -> type
         }
 


### PR DESCRIPTION
Fix a player state leak where the pause/header title could show the previously viewed series after opening an episode from another show, especially from Continue Watching.

- Clear stale `EpisodeManager` state before loading a different episode chain
- Refresh the player header after the new episode context is established
- Only use `EpisodeManager` for the player title/subtitle when it matches the active episode ID
- Fall back to the current navigation args when the cached episode context is stale

The player header preferred `EpisodeManager.getCurrentEpisode()` over the active navigation payload. If that singleton still contained the last watched show while a new episode session was being initialized, the pause screen could briefly or persistently show the wrong series title.