### PR TITLE
Add cross-season next episode playback

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/database/dao/SeasonDao.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/database/dao/SeasonDao.kt
@@ -26,6 +26,9 @@ interface SeasonDao {
     @Query("SELECT * FROM seasons WHERE tvShow = :tvShowId")
     fun getByTvShowIdAsFlow(tvShowId: String): Flow<List<Season>>
 
+    @Query("SELECT * FROM seasons WHERE tvShow = :tvShowId ORDER BY number")
+    fun getByTvShowId(tvShowId: String): List<Season>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(season: Season)
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
@@ -580,11 +580,13 @@ class PlayerMobileFragment : Fragment() {
                         withContext(Dispatchers.Main) {
                             EpisodeManager.setCurrentEpisode(type)
                             setupEpisodeNavigationButtons()
+                            refreshEpisodeNavigation(type)
                         }
                     }
                 } else {
                     EpisodeManager.setCurrentEpisode(type)
                     setupEpisodeNavigationButtons()
+                    refreshEpisodeNavigation(type)
                 }
             }
             is Video.Type.Movie -> {EpisodeManager.clearEpisodes()}
@@ -813,7 +815,33 @@ class PlayerMobileFragment : Fragment() {
             EpisodeManager::hasPreviousEpisode,
             viewModel::playPreviousEpisode
         )
-        handleNavigationButton(btnNext, EpisodeManager::hasNextEpisode, viewModel::playNextEpisode)
+        handleNavigationButton(btnNext, EpisodeManager::hasNextEpisode, ::playNextEpisodeAcrossSeasons)
+    }
+
+    private fun refreshEpisodeNavigation(type: Video.Type.Episode) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            EpisodeManager.ensureNextEpisodeAvailable(type, database)
+            withContext(Dispatchers.Main) {
+                setupEpisodeNavigationButtons()
+            }
+        }
+    }
+
+    private fun playNextEpisodeAcrossSeasons(autoplay: Boolean = false) {
+        val type = args.videoType as? Video.Type.Episode ?: return
+
+        lifecycleScope.launch {
+            val hasNextEpisode = withContext(Dispatchers.IO) {
+                EpisodeManager.ensureNextEpisodeAvailable(type, database)
+            }
+
+            setupEpisodeNavigationButtons()
+
+            if (!hasNextEpisode) return@launch
+            if (autoplay && !UserPreferences.autoplay) return@launch
+
+            viewModel.playNextEpisode()
+        }
     }
 
     private fun decodeBase64Uri(uri: String): String? {
@@ -1052,7 +1080,7 @@ class PlayerMobileFragment : Fragment() {
                             }
                     if (player.hasReallyFinished()) {
                         if (UserPreferences.autoplay) {
-                            viewModel.autoplayNextEpisode()
+                            playNextEpisodeAcrossSeasons(autoplay = true)
                         }
                     }
                 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -643,11 +643,36 @@ class PlayerTvFragment : Fragment() {
     private fun handleMediaNext(): Boolean {
         return when (args.videoType) {
             is Video.Type.Episode -> {
-                if (!EpisodeManager.hasNextEpisode()) return false
-                viewModel.playNextEpisode()
+                playNextEpisodeAcrossSeasons()
                 true
             }
             is Video.Type.Movie -> false
+        }
+    }
+
+    private fun refreshEpisodeNavigation(type: Video.Type.Episode) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            EpisodeManager.ensureNextEpisodeAvailable(type, database)
+            withContext(Dispatchers.Main) {
+                setupEpisodeNavigationButtons()
+            }
+        }
+    }
+
+    private fun playNextEpisodeAcrossSeasons(autoplay: Boolean = false) {
+        val type = args.videoType as? Video.Type.Episode ?: return
+
+        lifecycleScope.launch {
+            val hasNextEpisode = withContext(Dispatchers.IO) {
+                EpisodeManager.ensureNextEpisodeAvailable(type, database)
+            }
+
+            setupEpisodeNavigationButtons()
+
+            if (!hasNextEpisode) return@launch
+            if (autoplay && !UserPreferences.autoplay) return@launch
+
+            viewModel.playNextEpisode()
         }
     }
 
@@ -723,11 +748,13 @@ class PlayerTvFragment : Fragment() {
                             withContext(Dispatchers.Main) {
                                 EpisodeManager.setCurrentEpisode(type)
                                 setupEpisodeNavigationButtons()
+                                refreshEpisodeNavigation(type)
                             }
                         }
                     } else {
                         EpisodeManager.setCurrentEpisode(type)
                         setupEpisodeNavigationButtons()
+                        refreshEpisodeNavigation(type)
                     }
                 }
 
@@ -921,7 +948,7 @@ class PlayerTvFragment : Fragment() {
             handleNavigationButton(
                 btnNext,
                 EpisodeManager::hasNextEpisode,
-                viewModel::playNextEpisode
+                ::playNextEpisodeAcrossSeasons
             )
         }
 
@@ -1219,7 +1246,7 @@ class PlayerTvFragment : Fragment() {
                         }
                         if (player.hasReallyFinished()) {
                             if (UserPreferences.autoplay) {
-                                viewModel.autoplayNextEpisode()
+                                playNextEpisodeAcrossSeasons(autoplay = true)
                             }
                         }
                     }

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/EpisodeManager.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/EpisodeManager.kt
@@ -17,6 +17,22 @@ object EpisodeManager {
         currentIndex = 0
     }
 
+    private fun mergeEpisodes(list: List<Episode>) {
+        if (list.isEmpty()) return
+
+        val currentEpisodeId = getCurrentEpisode()?.id
+        val merged = (episodes + list)
+            .distinctBy { it.id }
+            .sortedWith(compareBy({ it.season.number }, { it.number }))
+
+        episodes.clear()
+        episodes.addAll(merged)
+
+        currentIndex = currentEpisodeId
+            ?.let { id -> episodes.indexOfFirst { it.id == id }.takeIf { it >= 0 } }
+            ?: 0
+    }
+
     suspend fun addEpisodesFromDb(type: Video.Type.Episode, database: AppDatabase) {
         val tvShowId = type.tvShow.id
         val seasonNumber = type.season.number
@@ -68,6 +84,66 @@ object EpisodeManager {
             }
             addEpisodes(convertToVideoTypeEpisodes(episodesFromDb, database, seasonNumber))
         }
+    }
+
+    suspend fun ensureNextEpisodeAvailable(type: Video.Type.Episode, database: AppDatabase): Boolean {
+        if (hasNextEpisode()) return true
+
+        val currentEpisode = getCurrentEpisode()
+            ?.takeIf { current -> current.id == type.id }
+            ?: type
+        val provider = UserPreferences.currentProvider ?: return false
+        val tvShowId = currentEpisode.tvShow.id
+        val currentSeasonNumber = currentEpisode.season.number
+
+        fun nextSeasonFrom(seasons: List<Season>): Season? =
+            seasons
+                .filter { season -> season.number > currentSeasonNumber }
+                .sortedBy { season -> season.number }
+                .firstOrNull()
+
+        var nextSeason = nextSeasonFrom(database.seasonDao().getByTvShowId(tvShowId))
+
+        if (nextSeason == null) {
+            runCatching { provider.getTvShow(tvShowId) }
+                .getOrNull()
+                ?.also { tvShow ->
+                    database.tvShowDao().save(tvShow)
+                    tvShow.seasons.forEach { season ->
+                        season.tvShow = tvShow
+                    }
+                    database.seasonDao().insertAll(tvShow.seasons)
+                    nextSeason = nextSeasonFrom(tvShow.seasons)
+                }
+        }
+
+        val seasonToLoad = nextSeason ?: return false
+        var nextSeasonEpisodes = database.episodeDao()
+            .getByTvShowIdAndSeasonNumber(tvShowId, seasonToLoad.number)
+
+        if (nextSeasonEpisodes.isEmpty() && seasonToLoad.id.isNotBlank()) {
+            nextSeasonEpisodes = runCatching {
+                provider.getEpisodesBySeason(seasonToLoad.id)
+            }.getOrDefault(emptyList()).also { fetchedEpisodes ->
+                if (fetchedEpisodes.isNotEmpty()) {
+                    fetchedEpisodes.forEach { episode ->
+                        episode.tvShow = episode.tvShow ?: seasonToLoad.tvShow
+                        episode.season = episode.season ?: seasonToLoad
+                    }
+                    database.episodeDao().insertAll(fetchedEpisodes)
+                }
+            }
+        }
+
+        if (nextSeasonEpisodes.isEmpty()) return false
+
+        nextSeasonEpisodes.forEach { episode ->
+            episode.tvShow = episode.tvShow ?: seasonToLoad.tvShow
+            episode.season = episode.season ?: seasonToLoad
+        }
+
+        mergeEpisodes(convertToVideoTypeEpisodes(nextSeasonEpisodes, database, seasonToLoad.number))
+        return hasNextEpisode()
     }
     fun clearEpisodes(){
         episodes.clear()


### PR DESCRIPTION
Add support for continuing into the next season when the current episode is the last one in its season.
Features:
- load the next season on demand in `EpisodeManager`
- keep next episode navigation working across season boundaries
- apply the same behavior to autoplay and manual next on mobile and TV